### PR TITLE
Replaced .ix by .loc to get rid of the future warning comment

### DIFF
--- a/odym/modules/ODYM_Classes.py
+++ b/odym/modules/ODYM_Classes.py
@@ -100,15 +100,15 @@ class MFAsystem(Obj):
     def IndexTableCheck(self):
         """ Check whether chosen classifications fit to dimensions of index table."""
         for indx in self.IndexTable.index:
-            if self.IndexTable.ix[indx]['Dimension']  != self.IndexTable.ix[indx]['Classification'].Dimension:
+            if self.IndexTable.loc[indx]['Dimension']  != self.IndexTable.loc[indx]['Classification'].Dimension:
                 raise ValueError('Dimension mismatch. Dimension of classifiation needs to fit to dimension of flow or parameter index. Found a mismatch for the following index: {foo}. Check your index table definition!'.format(foo = indx))
         if 'Time' not in self.IndexTable.index:
             raise ValueError(' "Time" aspect must be present in IndexTable. Please check your index table definition!')            
         if 'Element' not in self.IndexTable.index:
             raise ValueError(' "Element" aspect must be present in IndexTable. Please check your index table definition!')                            
-        if len(self.IndexTable.ix['Element'].Classification.Items) == 0:
+        if len(self.IndexTable.loc['Element'].Classification.Items) == 0:
             raise ValueError('Need at least one element in element list, please check your classification definition!')
-        if len(self.IndexTable.ix['Time'].Classification.Items) == 0:
+        if len(self.IndexTable.loc['Time'].Classification.Items) == 0:
             raise ValueError('Need at least one element in Time list, please check your classification definition!')
 
         return True
@@ -117,7 +117,7 @@ class MFAsystem(Obj):
         """ This method will construct empty numpy arrays (zeros) for all flows where the value is None and wheree the indices are given."""
         for key in self.FlowDict:
             if self.FlowDict[key].Values is None:
-                self.FlowDict[key].Values = np.zeros(tuple([len(self.IndexTable.set_index('IndexLetter').ix[x]['Classification'].Items) for x in self.FlowDict[key].Indices.split(',')]))   
+                self.FlowDict[key].Values = np.zeros(tuple([len(self.IndexTable.set_index('IndexLetter').loc[x]['Classification'].Items) for x in self.FlowDict[key].Indices.split(',')]))   
 #        Raw code, for development        
 #        Indices = 't,Ro,a,e'
 #        IndList = Indices.split(',')
@@ -128,13 +128,13 @@ class MFAsystem(Obj):
         """ This method will construct empty numpy arrays (zeros) for all stocks where the value is None and wheree the indices are given."""
         for key in self.StockDict:
             if self.StockDict[key].Values is None:
-                self.StockDict[key].Values = np.zeros(tuple([len(self.IndexTable.set_index('IndexLetter').ix[x]['Classification'].Items) for x in self.StockDict[key].Indices.split(',')]))   
+                self.StockDict[key].Values = np.zeros(tuple([len(self.IndexTable.set_index('IndexLetter').loc[x]['Classification'].Items) for x in self.StockDict[key].Indices.split(',')]))   
 
     def Initialize_ParameterValues(self):
         """ This method will construct empty numpy arrays (zeros) for all parameters where the value is None and wheree the indices are given."""
         for key in self.ParameterDict:
             if self.ParameterDict[key].Values is None:
-                self.ParameterDict[key].Values = np.zeros(tuple([len(self.IndexTable.set_index('IndexLetter').ix[x]['Classification'].Items) for x in self.ParameterDict[key].Indices.split(',')]))                   
+                self.ParameterDict[key].Values = np.zeros(tuple([len(self.IndexTable.set_index('IndexLetter').loc[x]['Classification'].Items) for x in self.ParameterDict[key].Indices.split(',')]))                   
                 
     def Consistency_Check(self):
         """ Method that check a readily defined system for consistency of dimensions, Value setting, etc. See detailed comments."""                
@@ -151,7 +151,7 @@ class MFAsystem(Obj):
         
         # 3) Check whethe all flow valua arrays match with the index structure:
         for key in self.FlowDict:
-            if tuple([len(self.IndexTable.set_index('IndexLetter').ix[x]['Classification'].Items) for x in self.FlowDict[key].Indices.split(',')]) != self.FlowDict[key].Values.shape:
+            if tuple([len(self.IndexTable.set_index('IndexLetter').loc[x]['Classification'].Items) for x in self.FlowDict[key].Indices.split(',')]) != self.FlowDict[key].Values.shape:
                 raise ValueError('Dimension mismatch. Dimension of flow value array does not fit to flow indices for flow {foo}. Check your flow and flow value definition!'.format(foo = key))
                 
         return A, True, True
@@ -164,7 +164,7 @@ class MFAsystem(Obj):
         and call the Einstein sum function np.einsum with the string 'tODGme->te', 
         and apply it to the flow values. 
         """
-        return np.einsum(self.FlowDict[FlowKey].Indices.replace(',','') + '->'+ self.IndexTable.ix['Time'].IndexLetter + self.IndexTable.ix['Element'].IndexLetter ,self.FlowDict[FlowKey].Values) 
+        return np.einsum(self.FlowDict[FlowKey].Indices.replace(',','') + '->'+ self.IndexTable.loc['Time'].IndexLetter + self.IndexTable.loc['Element'].IndexLetter ,self.FlowDict[FlowKey].Values) 
     
     def Stock_Sum_By_Element(self,StockKey):
         """ 
@@ -174,7 +174,7 @@ class MFAsystem(Obj):
         and call the Einstein sum function np.einsum with the string 'tcGme->te', 
         and apply it to the stock values. 
         """
-        return np.einsum(self.StockDict[StockKey].Indices.replace(',','') + '->'+ self.IndexTable.ix['Time'].IndexLetter + self.IndexTable.ix['Element'].IndexLetter ,self.StockDict[StockKey].Values) 
+        return np.einsum(self.StockDict[StockKey].Indices.replace(',','') + '->'+ self.IndexTable.loc['Time'].IndexLetter + self.IndexTable.loc['Element'].IndexLetter ,self.StockDict[StockKey].Values) 
                  
     def MassBalance(self, Element = None):
         """ 

--- a/odym/modules/ODYM_Functions.py
+++ b/odym/modules/ODYM_Functions.py
@@ -493,14 +493,14 @@ def ReadParameter(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Mast
         for m in range(0,len(ThisParIx)):
             ThisDim = ThisParIx[m]
             # Check whether index is present in parameter file:
-            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').ix[ThisDim].Classification.Name
+            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').loc[ThisDim].Classification.Name
             if ThisDimClassificationName != IList[m]:
                 Mylog.error('CLASSIFICATION ERROR: Classification ' + ThisDimClassificationName + ' for aspect ' +
                             ThisDim + ' of parameter ' + ThisPar +
                             ' must be identical to the specified classification of the corresponding parameter dimension, which is ' + IList[m])
                 break  # Stop parsing parameter, will cause model to halt
             
-            IndexSizesM.append(IndexTable.set_index('IndexLetter').ix[ThisDim]['IndexSize'])
+            IndexSizesM.append(IndexTable.set_index('IndexLetter').loc[ThisDim]['IndexSize'])
 
         # Read parameter values into array:
         Values = np.zeros((IndexSizesM))
@@ -518,7 +518,7 @@ def ReadParameter(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Mast
             for mx in range(0,len(IList)): # mx iterates over the aspects of the parameter 
                 CurrentItem = ValuesSheet.cell_value(cx + RowOffset, IM[mx])
                 try:
-                    TargetPosition.append(IndexTable.set_index('IndexLetter').ix[ThisParIx[mx]].Classification.Items.index(CurrentItem))
+                    TargetPosition.append(IndexTable.set_index('IndexLetter').loc[ThisParIx[mx]].Classification.Items.index(CurrentItem))
                 except:
                     break # Current parameter value is not needed for model, outside scope for a certain aspect. 
             if len(TargetPosition) == len(ThisParIx):
@@ -595,7 +595,7 @@ def ReadParameter(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Mast
         IndexSizesM  = [] # List of dimension size for model
         for m in range(0,len(ThisParIx)):
             ThisDim = ThisParIx[m]
-            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').ix[ThisDim].Classification.Name
+            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').loc[ThisDim].Classification.Name
             if ThisDimClassificationName != ComIList[m]:
                 Mylog.error('CLASSIFICATION ERROR: Classification ' + ThisDimClassificationName + ' for aspect ' +
                             ThisDim + ' of parameter ' + ThisPar +
@@ -603,7 +603,7 @@ def ReadParameter(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Mast
                             ComIList[m])
                 break  # Stop parsing parameter, will cause model to halt
                 
-            IndexSizesM.append(IndexTable.set_index('IndexLetter').ix[ThisDim]['IndexSize'])
+            IndexSizesM.append(IndexTable.set_index('IndexLetter').loc[ThisDim]['IndexSize'])
         
         # Read parameter values into array:
         Values = np.zeros((IndexSizesM))
@@ -624,7 +624,7 @@ def ReadParameter(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Mast
                     CurrentItem = ValuesSheet.cell_value(m + RowOffset, mc)
                 try:
                     IX   = ThisParIx.find(RIIndexLetter[mc])
-                    TPIX = IndexTable.set_index('IndexLetter').ix[RIIndexLetter[mc]].Classification.Items.index(CurrentItem)
+                    TPIX = IndexTable.set_index('IndexLetter').loc[RIIndexLetter[mc]].Classification.Items.index(CurrentItem)
                     TP_RD.append((IX,TPIX))
                 except:
                     TP_RD.append(None)
@@ -641,7 +641,7 @@ def ReadParameter(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Mast
                     CurrentItem = ValuesSheet.cell_value(mc, n + ColOffset)
                 try:
                     IX = ThisParIx.find(CIIndexLetter[mc])
-                    TPIX = IndexTable.set_index('IndexLetter').ix[CIIndexLetter[mc]].Classification.Items.index(CurrentItem)
+                    TPIX = IndexTable.set_index('IndexLetter').loc[CIIndexLetter[mc]].Classification.Items.index(CurrentItem)
                     TP_CD.append((IX,TPIX))
                 except:
                     TP_CD.append(None)
@@ -753,14 +753,14 @@ def ReadParameterV2(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Ma
         for m in range(0,len(ThisParIx)):
             ThisDim = ThisParIx[m]
             # Check whether index is present in parameter file:
-            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').ix[ThisDim].Classification.Name
+            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').loc[ThisDim].Classification.Name
             if ThisDimClassificationName != IList[m]:
                 Mylog.error('CLASSIFICATION ERROR: Classification ' + ThisDimClassificationName + ' for aspect ' +
                             ThisDim + ' of parameter ' + ThisPar +
                             ' must be identical to the specified classification of the corresponding parameter dimension, which is ' + IList[m])
                 break  # Stop parsing parameter, will cause model to halt
             
-            IndexSizesM.append(IndexTable.set_index('IndexLetter').ix[ThisDim]['IndexSize'])
+            IndexSizesM.append(IndexTable.set_index('IndexLetter').loc[ThisDim]['IndexSize'])
 
         # Read parameter values into array, uncertainty into list:
         Values      = np.zeros((IndexSizesM)) # Array for parameter values
@@ -779,7 +779,7 @@ def ReadParameterV2(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Ma
             for mx in range(0,len(IList)): # mx iterates over the aspects of the parameter 
                 CurrentItem = ValuesSheet.cell_value(cx + RowOffset, IM[mx])
                 try:
-                    TargetPosition.append(IndexTable.set_index('IndexLetter').ix[ThisParIx[mx]].Classification.Items.index(CurrentItem))
+                    TargetPosition.append(IndexTable.set_index('IndexLetter').loc[ThisParIx[mx]].Classification.Items.index(CurrentItem))
                 except:
                     break # Current parameter value is not needed for model, outside scope for a certain aspect. 
             if len(TargetPosition) == len(ThisParIx):
@@ -853,7 +853,7 @@ def ReadParameterV2(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Ma
         IndexSizesM  = [] # List of dimension size for model
         for m in range(0,len(ThisParIx)):
             ThisDim = ThisParIx[m]
-            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').ix[ThisDim].Classification.Name
+            ThisDimClassificationName  = IndexTable.set_index('IndexLetter').loc[ThisDim].Classification.Name
             if ThisDimClassificationName != ComIList[m]:
                 Mylog.error('CLASSIFICATION ERROR: Classification ' + ThisDimClassificationName + ' for aspect ' +
                             ThisDim + ' of parameter ' + ThisPar +
@@ -861,7 +861,7 @@ def ReadParameterV2(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Ma
                             ComIList[m])
                 break  # Stop parsing parameter, will cause model to halt
                 
-            IndexSizesM.append(IndexTable.set_index('IndexLetter').ix[ThisDim]['IndexSize'])
+            IndexSizesM.append(IndexTable.set_index('IndexLetter').loc[ThisDim]['IndexSize'])
         
         # Read parameter values into array:
         Values      = np.zeros((IndexSizesM)) # Array for parameter values
@@ -885,7 +885,7 @@ def ReadParameterV2(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Ma
                     CurrentItem = ValuesSheet.cell_value(m + RowOffset, mc)
                 try:
                     IX   = ThisParIx.find(RIIndexLetter[mc])
-                    TPIX = IndexTable.set_index('IndexLetter').ix[RIIndexLetter[mc]].Classification.Items.index(CurrentItem)
+                    TPIX = IndexTable.set_index('IndexLetter').loc[RIIndexLetter[mc]].Classification.Items.index(CurrentItem)
                     TP_RD.append((IX,TPIX))
                 except:
                     TP_RD.append(None)
@@ -903,7 +903,7 @@ def ReadParameterV2(ParPath, ThisPar, ThisParIx, IndexMatch, ThisParLayerSel, Ma
                     CurrentItem = ValuesSheet.cell_value(mc, n + ColOffset)
                 try:
                     IX = ThisParIx.find(CIIndexLetter[mc])
-                    TPIX = IndexTable.set_index('IndexLetter').ix[CIIndexLetter[mc]].Classification.Items.index(CurrentItem)
+                    TPIX = IndexTable.set_index('IndexLetter').loc[CIIndexLetter[mc]].Classification.Items.index(CurrentItem)
                     TP_CD.append((IX,TPIX))
                 except:
                     TP_CD.append(None)


### PR DESCRIPTION
Hi,

I was getting future warning comments when running the code and this was polluting the log files, so I replaced all instances of .ix by .loc in ODYM_Classes.py and ODYM_Functions.py. This is very minor but I thought it might annoy others as well. so here is a pull request.

The warning message was:

FutureWarning:
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated
return getattr(section, self.name)[new_key]