### PR TITLE
Adapt check_dataset to check also data subfolders (PL_SubFolder)

### DIFF
--- a/odym/modules/ODYM_Functions.py
+++ b/odym/modules/ODYM_Functions.py
@@ -1413,19 +1413,21 @@ def convert_log(file, file_format='html'):
     output = pypandoc.convert_file(file, file_format, outputfile=output_filename)
     assert output == ""
 
-def check_dataset(path,PL_Names,PL_Version,Mylog):
+def check_dataset(path,PL_Names,PL_Version,PL_SubFolder,Mylog):
     """
-    Checks that every parameter in Pl_Names with the corrsponding version PL_Versions is in the folder given by path
+    Checks that every parameter in Pl_Names with the corrsponding version PL_Versions is in the folder given by path, or subfolder given by PL_SubFolder
 
     :param path: Dataset folder
     :param PL_Names: List of parameters names
     :param PL_versions: List of parameters versions
+    :param PL_SubFolder: List of data subfolder names
     :param Mylog: log file
 
     """
     for m in range(len(PL_Names)):
         if PL_Names[m]+'_'+PL_Version[m]+'.xlsx' not in os.listdir(path):
-            Mylog.error(PL_Names[m]+'_'+PL_Version[m]+'.xlsx not in the dataset.')
+            if PL_Names[m]+'_'+PL_Version[m]+'.xlsx' not in os.listdir(os.path.join(path, PL_SubFolder[m])):
+                Mylog.error(PL_Names[m]+'_'+PL_Version[m]+'.xlsx not in the dataset.')
     
     
 # The End


### PR DESCRIPTION
As input data can also be located in subfolders of the dataset folder (new, since commit 07f93696b9e223aad259be2e4f973fec4bdc7da8), check_dataset should also check these subfolders before reporting an error to the log file.