### PR TITLE
fix Processing_methods - interpolate

### DIFF
--- a/src/odym/functions/parameters.py
+++ b/src/odym/functions/parameters.py
@@ -1300,11 +1300,16 @@ def ReadParameterXLSX(
             )
             count_neg = (Values < 0).sum()
             if count_neg > 0:
-                Values[Values < 0] = 0
-                Mylog.info(
-                    str(count_neg)
-                    + " negative values from spline interpolation set to 0."
-                )
+                if min(y) <0: # test if negative target values are included (thus, desired), if yes, no correction of negative values
+                    Mylog.info(
+                        "Interpolation contains negative target values, thus no correction for negative values."                        
+                    )
+                else:
+                    Values[Values < 0] = 0
+                    Mylog.info(
+                        str(count_neg)
+                        + " negative values from spline interpolation set to 0."
+                    )
 
         elif processing.startswith("copy"):
             if len(processing.split("_")) != 5:


### PR DESCRIPTION
The interpolation function in 'Processing_methods' in 'ReadParameterXLSX(...)' includes a check for non-negativity of outcomes of the (spline) interpolation and sets all negative outcome values to zero. However, as in the case of 6_MIP_GWP_Bio (RECC model), negative values can be desired. This fix adds a check to only replace negative outcome values with zero if there are no negative target values handed over to the interpolation function.